### PR TITLE
Switching organisations where sensor data archives will live under

### DIFF
--- a/sensorsafrica/management/commands/upload_to_ckan.py
+++ b/sensorsafrica/management/commands/upload_to_ckan.py
@@ -16,9 +16,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         openAFRICA_API_KEY = os.environ.get("openAFRICA_API_KEY")
-        openAFRICA_CFA_ID = os.environ.get("openAFRICA_CFA_ID")
         openAFRICA_URL = "https://africaopendata.org"
-
         ckan = ckanapi.RemoteCKAN(openAFRICA_URL, apikey=openAFRICA_API_KEY)
 
         city_queryset = (
@@ -33,7 +31,7 @@ class Command(BaseCommand):
 
             try:
                 package = ckan.action.package_create(
-                    owner_org=openAFRICA_CFA_ID,
+                    owner_org="sensors-africa",
                     name="sensorsafrica-airquality-archive-" + slugify(city),
                     title="sensors.AFRICA Air Quality Archive " + city,
                     groups=[{"name": "sensorsafrica-airquality-archive"}]


### PR DESCRIPTION
## Description

Addressing the request:
> I see that you're uploading historical sensors.AFRICA data to openAFRICA, under the CfA profile. Could we rather move all this to the new sensors.AFRICA profile that I've just created? Having it under their own profile would help the team build traction & reuse. Thnx!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation