### PR TITLE
[HOTFIX] Command cache_lastactive_nodes_data

### DIFF
--- a/sensorsafrica/management/commands/cache_lastactive_nodes_data.py
+++ b/sensorsafrica/management/commands/cache_lastactive_nodes_data.py
@@ -21,5 +21,5 @@ class Command(BaseCommand):
             LastActiveNodes.objects.update_or_create(
                 node=Node(pk=data["sensor__node"]),
                 location=SensorLocation(pk=data["location"]),
-                last_data_received_at=data["timestamp"],
+                defaults={"last_data_received_at": data["timestamp"]},
             )


### PR DESCRIPTION
## Description

Fix error duplicate key value violates unique constraint "sensorsafrica_lastactivenodes_node_id_location_id_de7d6ca3_uniq". The several filters were too restrictive and as a result the database does not find such row.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation