### PR TITLE
last_data_received_at should be based on last sent PM sensor data

### DIFF
--- a/sensorsafrica/management/commands/cache_lastactive_nodes_data.py
+++ b/sensorsafrica/management/commands/cache_lastactive_nodes_data.py
@@ -14,9 +14,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for data in (
-            SensorData.objects.values("sensor__node", "location")
-            .order_by("sensor__node__id", "location__id")
-            .annotate(timestamp=Max("timestamp"))
+            SensorData.objects
+                .filter(sensordatavalues__value_type__in=["P1", "P2"])
+                .values("sensor__node", "location")
+                .order_by("sensor__node__id", "location__id")
+                .annotate(timestamp=Max("timestamp"))
         ):
             LastActiveNodes.objects.update_or_create(
                 node=Node(pk=data["sensor__node"]),


### PR DESCRIPTION
## Description

Sometimes the sensor stops sending PM data but keeps sending humidity/temperature values and therefore we miss the PM data. This PR makes a change to prioritize caching of last received based on the PM data.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation