### PR TITLE
[Feature] Admin see all active sensors, public see past 3 months

### DIFF
--- a/sensorsafrica/api/v2/views.py
+++ b/sensorsafrica/api/v2/views.py
@@ -206,6 +206,7 @@ class CityView(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = CitySerializer
     pagination_class = StandardResultsSetPagination
 
+
 class NodesView(viewsets.ViewSet):
     def list(self, request):
         nodes = []


### PR DESCRIPTION
## Description

Allow for public view of "inactive sensors" for past 3 months.
For admins, show "inactive sensors" for all time.

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation