### PR TITLE
Externalize Slack Webhook failures_only Config

### DIFF
--- a/sensorsafrica/celeryapp.py
+++ b/sensorsafrica/celeryapp.py
@@ -16,4 +16,10 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 # Autodiscover tasks in tasks.py
 app.autodiscover_tasks()
 
-slack_app = Slackify(app, os.environ.get("SENSORSAFRICA_CELERY_SLACK_WEBHOOK", ""))
+SLACK_WEBHOOK = os.environ.get("SENSORSAFRICA_CELERY_SLACK_WEBHOOK", "")
+SLACK_WEBHOOK_FAILURES_ONLY = os.environ.get(
+    "SENSORSAFRICA_CELERY_SLACK_WEBHOOK_FAILURES_ONLY", "").strip().lower() in ('true', 't', '1')
+
+options = {'failures_only': SLACK_WEBHOOK_FAILURES_ONLY}
+
+slack_app = Slackify(app, SLACK_WEBHOOK, **options)


### PR DESCRIPTION
## Description

Add `SENSORSAFRICA_CELERY_SLACK_WEBHOOK_FAILURES_ONLY` environment variable for slack webhook `failures_only` option

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation