### PR TITLE
Replicate lufdetan feinstaub v1 routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,4 @@ celerybeat.pid
 logs/
 
 /static
+/sensorsafrica/static/**/*.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ greenlet==0.4.12
 whitenoise==4.1.2
 
 pylama==7.6.6
-pytest==4.1.1
+pytest==5.2.1
 pytest-django==3.4.5
 
 ckanapi==4.1

--- a/sensorsafrica/api/v1/router.py
+++ b/sensorsafrica/api/v1/router.py
@@ -9,7 +9,7 @@ from feinstaub.sensors.views import (
     SensorDataView,
 )
 
-from .views import SensorDataView as SensorsAfricaSensorDataView
+from .views import SensorDataView as SensorsAfricaSensorDataView, FilterView
 
 from rest_framework import routers
 
@@ -23,5 +23,6 @@ router.register(r"now", NowView)
 router.register(r"user", UsersView)
 router.register(r"sensors/(?P<sensor_id>\d+)",
                 SensorsAfricaSensorDataView, basename="sensors")
+router.register(r"filter", FilterView, basename="filter")
 
 api_urls = router.urls

--- a/sensorsafrica/api/v1/router.py
+++ b/sensorsafrica/api/v1/router.py
@@ -9,6 +9,8 @@ from feinstaub.sensors.views import (
     SensorDataView,
 )
 
+from .views import SensorDataView as SensorsAfricaSensorDataView
+
 from rest_framework import routers
 
 router = routers.DefaultRouter()
@@ -19,5 +21,7 @@ router.register(r"data", SensorDataView)
 router.register(r"statistics", StatisticsView, basename="statistics")
 router.register(r"now", NowView)
 router.register(r"user", UsersView)
+router.register(r"sensors/(?P<sensor_id>\d+)",
+                SensorsAfricaSensorDataView, basename="sensors")
 
 api_urls = router.urls

--- a/sensorsafrica/api/v1/serializers.py
+++ b/sensorsafrica/api/v1/serializers.py
@@ -9,8 +9,10 @@ class SensorDataValueSerializer(serializers.ModelSerializer):
         model = SensorDataValue
         fields = ['value_type', 'value']
 
+
 class SensorDataSerializer(serializers.ModelSerializer):
     sensordatavalues = SensorDataValueSerializer(many=True)
+
     class Meta:
         model = SensorData
-        fields = ['sensor', 'timestamp', 'sensordatavalues']
+        fields = ['timestamp', 'sensordatavalues']

--- a/sensorsafrica/api/v1/serializers.py
+++ b/sensorsafrica/api/v1/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from feinstaub.sensors.models import (
+    SensorData,
+    SensorDataValue
+)
+
+class SensorDataValueSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SensorDataValue
+        fields = ['value_type', 'value']
+
+class SensorDataSerializer(serializers.ModelSerializer):
+    sensordatavalues = SensorDataValueSerializer(many=True)
+    class Meta:
+        model = SensorData
+        fields = ['sensor', 'timestamp', 'sensordatavalues']

--- a/sensorsafrica/api/v1/serializers.py
+++ b/sensorsafrica/api/v1/serializers.py
@@ -4,6 +4,7 @@ from feinstaub.sensors.models import (
     SensorDataValue
 )
 
+
 class SensorDataValueSerializer(serializers.ModelSerializer):
     class Meta:
         model = SensorDataValue

--- a/sensorsafrica/api/v1/views.py
+++ b/sensorsafrica/api/v1/views.py
@@ -28,3 +28,23 @@ class SensorDataView(mixins.ListModelMixin, viewsets.GenericViewSet):
             .only('sensor', 'timestamp')
             .prefetch_related('sensordatavalues')
         )
+
+
+class FilterView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    serializer_class = SensorDataSerializer
+
+    def get_queryset(self):
+        sensor_type = self.request.GET.get('type', r'\w+')
+        country = self.request.GET.get('country', r'\w+')
+        city = self.request.GET.get('city', r'\w+')
+        return (
+            SensorData.objects
+            .filter(
+                timestamp__gte=timezone.now() - datetime.timedelta(minutes=5),
+                sensor__sensor_type__uid__iregex=sensor_type,
+                location__country__iregex=country,
+                location__city__iregex=city
+            )
+            .only('sensor', 'timestamp')
+            .prefetch_related('sensordatavalues')
+        )

--- a/sensorsafrica/api/v1/views.py
+++ b/sensorsafrica/api/v1/views.py
@@ -1,0 +1,30 @@
+import datetime
+import pytz
+import json
+
+from rest_framework.exceptions import ValidationError
+
+from django.conf import settings
+from django.utils import timezone
+from dateutil.relativedelta import relativedelta
+from django.db.models import ExpressionWrapper, F, FloatField, Max, Min, Sum, Avg, Q
+from django.db.models.functions import Cast, TruncDate
+from rest_framework import mixins, pagination, viewsets
+
+from .serializers import SensorDataSerializer
+from feinstaub.sensors.models import SensorData
+
+
+class SensorDataView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    serializer_class = SensorDataSerializer
+
+    def get_queryset(self):
+        return (
+            SensorData.objects
+            .filter(
+                timestamp__gte=timezone.now() - datetime.timedelta(minutes=5),
+                sensor=self.kwargs["sensor_id"]
+            )
+            .only('sensor', 'timestamp')
+            .prefetch_related('sensordatavalues')
+        )

--- a/sensorsafrica/management/commands/cache_static_json_data.py
+++ b/sensorsafrica/management/commands/cache_static_json_data.py
@@ -1,0 +1,78 @@
+from django.core.management import BaseCommand
+from django.core.cache import cache
+
+from django.conf import settings
+
+from django.forms.models import model_to_dict
+
+from feinstaub.sensors.models import SensorLocation, Sensor
+
+import os
+import json
+import datetime
+from django.utils import timezone
+
+from django.db import connection
+
+from rest_framework import serializers
+
+
+class SensorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Sensor
+        fields = "__all__"
+
+class SensorLocationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SensorLocation
+        fields = "__all__"
+
+
+class Command(BaseCommand):
+    help = ""
+
+    def add_arguments(self, parser):
+        parser.add_argument('--interval', type=str)
+
+    def handle(self, *args, **options):
+        intervals = {'5m': '5 minutes', '1h': '1 hour', '24h': '24 hours'}
+        paths = {'5m': '../../static/v2/data.json',
+                 '1h': '../../static/v2/data.1h.json', '24h': '../../static/v2/data.24h.json'}
+        cursor = connection.cursor()
+        cursor.execute('''
+            SELECT sd.sensor_id, sdv.value_type, AVG(CAST(sdv."value" AS FLOAT)) as "value", COUNT("value"), sd.location_id
+                FROM sensors_sensordata sd
+                    INNER JOIN sensors_sensordatavalue sdv
+                        ON  sd.id = sdv.sensordata_id WHERE "timestamp" >= (NOW() - interval %s)
+                GROUP BY sd.sensor_id, sdv.value_type, sd.location_id
+        ''', [intervals[options['interval']]])
+
+        data = {}
+        while True:
+            row = cursor.fetchone()
+            if row == None:
+                break
+
+            if row[0] in data:
+                data[row[0]]['sensordatavalues'].append(dict({
+                    'samples': row[3],
+                    'value': row[2],
+                    'value_type': row[1]
+                }))
+            else:
+                data[row[0]] = dict({
+                    'location': SensorLocationSerializer(SensorLocation.objects.get(pk=row[4])).data,
+                    'sensor': SensorSerializer(Sensor.objects.get(pk=row[0])).data,
+                    'sensordatavalues': [{
+                        'samples': row[3],
+                        'value': row[2],
+                        'value_type': row[1]
+                    }]
+                })
+
+        with open(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            paths[options['interval']]),
+            'w'
+        ) as f:
+            json.dump(list(data.values()), f)

--- a/sensorsafrica/management/commands/cache_static_json_data.py
+++ b/sensorsafrica/management/commands/cache_static_json_data.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         data = {}
         while True:
             row = cursor.fetchone()
-            if row == None:
+            if row is None:
                 break
 
             if row[0] in data:
@@ -88,7 +88,8 @@ class Command(BaseCommand):
 
         for path in paths[options['interval']]:
             with open(
-                os.path.join(os.path.dirname(os.path.abspath(__file__)), path), 'w'
+                os.path.join(os.path.dirname(
+                    os.path.abspath(__file__)), path), 'w'
             ) as f:
                 if 'dust' in path:
                     json.dump(list(filter(

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -94,16 +94,10 @@ WSGI_APPLICATION = "sensorsafrica.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 
-# DATABASE_URL = "postgres://sensorsafrica:sensorsafrica@postgres:5432/sensorsafrica"
-
-DATABASE_URL = "postgres://htools:EFiNop6PMKBbeE6@cfa-general.cfgmtx8ishfx.eu-west-1.rds.amazonaws.com:54321/htools-airquality-api"
-
-# "postgres://sensorsafrica:sensorsafrica@sensorsafrica-staging.cfgmtx8ishfx.eu-west-1.rds.amazonaws.com:5432/sensorsafrica"
-
-# os.getenv(
-#     "SENSORSAFRICA_DATABASE_URL",
-#     "postgres://sensorsafrica:sensorsafrica@localhost:5432/sensorsafrica",
-# )
+DATABASE_URL = os.getenv(
+    "SENSORSAFRICA_DATABASE_URL",
+    "postgres://sensorsafrica:sensorsafrica@localhost:5432/sensorsafrica",
+)
 DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
 
 
@@ -148,7 +142,8 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 
 # Celery Broker
-CELERY_BROKER_URL = os.environ.get("SENSORSAFRICA_RABBITMQ_URL", "amqp://sensorsafrica:sensorsafrica@localhost//")
+CELERY_BROKER_URL = os.environ.get(
+    "SENSORSAFRICA_RABBITMQ_URL", "amqp://sensorsafrica:sensorsafrica@localhost//")
 CELERY_IGNORE_RESULT = True
 
 CELERY_BEAT_SCHEDULE = {

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -94,10 +94,16 @@ WSGI_APPLICATION = "sensorsafrica.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
 
-DATABASE_URL = os.getenv(
-    "SENSORSAFRICA_DATABASE_URL",
-    "postgres://sensorsafrica:sensorsafrica@localhost:5432/sensorsafrica",
-)
+# DATABASE_URL = "postgres://sensorsafrica:sensorsafrica@postgres:5432/sensorsafrica"
+
+DATABASE_URL = "postgres://htools:EFiNop6PMKBbeE6@cfa-general.cfgmtx8ishfx.eu-west-1.rds.amazonaws.com:54321/htools-airquality-api"
+
+# "postgres://sensorsafrica:sensorsafrica@sensorsafrica-staging.cfgmtx8ishfx.eu-west-1.rds.amazonaws.com:5432/sensorsafrica"
+
+# os.getenv(
+#     "SENSORSAFRICA_DATABASE_URL",
+#     "postgres://sensorsafrica:sensorsafrica@localhost:5432/sensorsafrica",
+# )
 DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
 
 
@@ -157,6 +163,14 @@ CELERY_BEAT_SCHEDULE = {
     "cache-lastactive-nodes-task": {
         "task": "sensorsafrica.tasks.cache_lastactive_nodes_data",
         "schedule": crontab(minute="*/5")
+    },
+    "cache-static-json-data": {
+        "task": "sensorsafrica.tasks.cache_static_json_data",
+        "schedule": crontab(minute="*/5")
+    },
+    "cache-static-json-data-1h-24h": {
+        "task": "sensorsafrica.tasks.cache_static_json_data_1h_24h",
+        "schedule": crontab(hour="*", minute=0)
     },
 }
 

--- a/sensorsafrica/tasks.py
+++ b/sensorsafrica/tasks.py
@@ -15,3 +15,14 @@ def archive_data():
 @shared_task
 def cache_lastactive_nodes_data():
     call_command("cache_lastactive_nodes_data")
+
+
+@shared_task
+def cache_static_json_data():
+    call_command("cache_static_json_data", interval='5m')
+
+
+@shared_task
+def cache_static_json_data_1h_24h():
+    call_command("cache_static_json_data", interval='1h')
+    call_command("cache_static_json_data", interval='24h')

--- a/sensorsafrica/tests/conftest.py
+++ b/sensorsafrica/tests/conftest.py
@@ -37,7 +37,8 @@ def location():
 
 @pytest.fixture
 def sensor_type():
-    st, x = SensorType.objects.get_or_create(uid="a", name="b", manufacturer="c")
+    st, x = SensorType.objects.get_or_create(
+        uid="a", name="b", manufacturer="c")
     return st
 
 
@@ -58,22 +59,32 @@ def sensor(logged_in_user, sensor_type, node):
 @pytest.fixture
 def locations():
     return [
-        SensorLocation.objects.get_or_create(city="Dar es Salaam", description="active")[0],
-        SensorLocation.objects.get_or_create(city="Bagamoyo", description="inactive")[0],
-        SensorLocation.objects.get_or_create(city="Mombasa", description="inactive")[0],
-        SensorLocation.objects.get_or_create(city="Nairobi", description="inactive")[0],
-        SensorLocation.objects.get_or_create(city="Dar es Salaam", description="active | some other node location")[0],
+        SensorLocation.objects.get_or_create(
+            city="Dar es Salaam", country="Tanzania", description="active")[0],
+        SensorLocation.objects.get_or_create(
+            city="Bagamoyo", country="Tanzania", description="inactive")[0],
+        SensorLocation.objects.get_or_create(
+            city="Mombasa", country="Kenya", description="inactive")[0],
+        SensorLocation.objects.get_or_create(
+            city="Nairobi", country="Kenya", description="inactive")[0],
+        SensorLocation.objects.get_or_create(
+            city="Dar es Salaam", country="Tanzania", description="active | some other node location")[0],
     ]
 
 
 @pytest.fixture
 def nodes(logged_in_user, locations):
     return [
-        Node.objects.get_or_create(uid="0", owner=logged_in_user, location=locations[0])[0],
-        Node.objects.get_or_create(uid="1", owner=logged_in_user, location=locations[1])[0],
-        Node.objects.get_or_create(uid="2", owner=logged_in_user, location=locations[2])[0],
-        Node.objects.get_or_create(uid="3", owner=logged_in_user, location=locations[3])[0],
-        Node.objects.get_or_create(uid="4", owner=logged_in_user, location=locations[4])[0],
+        Node.objects.get_or_create(
+            uid="0", owner=logged_in_user, location=locations[0])[0],
+        Node.objects.get_or_create(
+            uid="1", owner=logged_in_user, location=locations[1])[0],
+        Node.objects.get_or_create(
+            uid="2", owner=logged_in_user, location=locations[2])[0],
+        Node.objects.get_or_create(
+            uid="3", owner=logged_in_user, location=locations[3])[0],
+        Node.objects.get_or_create(
+            uid="4", owner=logged_in_user, location=locations[4])[0],
     ]
 
 
@@ -81,15 +92,20 @@ def nodes(logged_in_user, locations):
 def sensors(sensor_type, nodes):
     return [
         # Active Dar Sensor
-        Sensor.objects.get_or_create(node=nodes[0], sensor_type=sensor_type, public=True)[0],
+        Sensor.objects.get_or_create(
+            node=nodes[0], sensor_type=sensor_type, public=True)[0],
         # Inactive with last data push beyond active threshold
-        Sensor.objects.get_or_create(node=nodes[1], sensor_type=sensor_type)[0],
+        Sensor.objects.get_or_create(
+            node=nodes[1], sensor_type=sensor_type)[0],
         # Inactive without any data
-        Sensor.objects.get_or_create(node=nodes[2], sensor_type=sensor_type)[0],
+        Sensor.objects.get_or_create(
+            node=nodes[2], sensor_type=sensor_type)[0],
         # Active Nairobi Sensor
-        Sensor.objects.get_or_create(node=nodes[3], sensor_type=sensor_type)[0],
+        Sensor.objects.get_or_create(
+            node=nodes[3], sensor_type=sensor_type)[0],
         # Active Dar Sensor another location
-        Sensor.objects.get_or_create(node=nodes[4], sensor_type=sensor_type)[0],
+        Sensor.objects.get_or_create(
+            node=nodes[4], sensor_type=sensor_type)[0],
     ]
 
 
@@ -111,11 +127,13 @@ def sensordata(sensors, locations):
     ]
     # Nairobi SensorData
     for i in range(100):
-        sensor_datas.append(SensorData(sensor=sensors[3], location=locations[3]))
+        sensor_datas.append(SensorData(
+            sensor=sensors[3], location=locations[3]))
 
     # Dar es Salaam another node location SensorData
     for i in range(6):
-        sensor_datas.append(SensorData(sensor=sensors[4], location=locations[4]))
+        sensor_datas.append(SensorData(
+            sensor=sensors[4], location=locations[4]))
 
     data = SensorData.objects.bulk_create(sensor_datas)
 
@@ -130,7 +148,8 @@ def sensordata(sensors, locations):
 def datavalues(sensors, sensordata):
     data_values = [
         # Bagamoyo
-        SensorDataValue(sensordata=sensordata[0], value="2", value_type="humidity"),
+        SensorDataValue(
+            sensordata=sensordata[0], value="2", value_type="humidity"),
         # Dar es salaam a day ago's data
         SensorDataValue(sensordata=sensordata[1], value="1", value_type="P2"),
         SensorDataValue(sensordata=sensordata[2], value="2", value_type="P2"),
@@ -150,12 +169,14 @@ def datavalues(sensors, sensordata):
     # Nairobi SensorDataValues
     for i in range(100):
         data_values.append(
-            SensorDataValue(sensordata=sensordata[9 + i], value="0", value_type="P2")
+            SensorDataValue(
+                sensordata=sensordata[9 + i], value="0", value_type="P2")
         )
 
     # Dar es Salaam another node location SensorDataValues
     for i in range(6):
-        data_values.append(SensorDataValue(sensordata=sensordata[109 + i], value="0.0", value_type="P2"))
+        data_values.append(SensorDataValue(
+            sensordata=sensordata[109 + i], value="0.0", value_type="P2"))
 
     values = SensorDataValue.objects.bulk_create(data_values)
 

--- a/sensorsafrica/tests/test_filter_view.py
+++ b/sensorsafrica/tests/test_filter_view.py
@@ -1,0 +1,36 @@
+import pytest
+import datetime
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+class TestGettingFilteringPast5MinutesData:
+    def test_getting_past_5_minutes_data_for_sensor_type(self, client, sensor_type, sensordata):
+        response = client.get("/v1/filter/?type=%s" % sensor_type.uid, format="json")
+        assert response.status_code == 200
+
+        results = response.json()
+
+        # subtract 1 data since one the many data is set as posted 40 minutes ago, not 5 minutes
+        assert len(results) == (len(list(filter(
+            lambda sd: sd.sensor.sensor_type.uid == sensor_type.uid, sensordata))) - 1)
+
+    def test_getting_past_5_minutes_data_for_sensor_city(self, client, sensordata):
+        response = client.get("/v1/filter/?city=Bagamoyo", format="json")
+        assert response.status_code == 200
+
+        results = response.json()
+
+        # no subtract 1 since the 1 data posted 40 minutes ago is for Dar es Salaam
+        assert len(results) == (len(list(filter(
+            lambda sd: sd.location.city == "Bagamoyo", sensordata))))
+
+    def test_getting_past_5_minutes_data_for_sensor_country(self, client, sensordata):
+        response = client.get("/v1/filter/?country=Tanzania", format="json")
+        assert response.status_code == 200
+
+        results = response.json()
+
+        # subtract 1 data since one the many data in Tanzania is set as posted 40 minutes ago, not 5 minutes
+        assert len(results) == (len(list(filter(
+            lambda sd: sd.location.country == "Tanzania", sensordata))) - 1)

--- a/sensorsafrica/tests/test_sensor_view.py
+++ b/sensorsafrica/tests/test_sensor_view.py
@@ -1,0 +1,19 @@
+import pytest
+import datetime
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+class TestGettingSensorPast5MinutesData:
+    def test_getting_past_5_minutes_data_for_sensor_with_id(self, client, sensors):
+        response = client.get("/v1/sensors/%s/" % sensors[0].id, format="json")
+        assert response.status_code == 200
+
+        results = response.json()
+
+        # 7 are recent since one the 8 data is 40 minutes ago
+        assert len(results) == 7
+        assert "sensordatavalues" in results[0]
+        assert "timestamp" in results[0]
+        assert "value_type" in results[0]['sensordatavalues'][0]
+        assert "value" in results[0]['sensordatavalues'][0]


### PR DESCRIPTION
## Description

Fixes missing code/functionality for these routes.

- [x] `/v1/sensor/{sensor_id}/ `  - all measurements of the last 5 minutes for one sensor
- [x] `/v1/filter?city=&country=&type=` - 5 minutes filtered by query
- [x] `/static/v2/data.json` - average of all measurements per sensor of the last 5 minutes for all sensors
- [x] `/static/v2/data.1h.json` - average of all measurements per sensor of the last hour
- [x] `/static/v2/data.24h.json` - average of all measurements per sensor of the 24 hours
- [x] `static/v2/data.dust.min.json` - same as data.json but dust sensors only
- [x] `/static/v2/data.temp.min.json` - same as data.json but temp

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation