### PR TITLE
[Hotfix] Exclude `timestamp` values from averaging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ gevent==1.2.2
 greenlet==0.4.12
 whitenoise==4.1.2
 
+eradicate==1.0
 pylama==7.6.6
 pytest==5.2.1
 pytest-django==3.4.5

--- a/sensorsafrica/management/commands/cache_static_json_data.py
+++ b/sensorsafrica/management/commands/cache_static_json_data.py
@@ -59,7 +59,9 @@ class Command(BaseCommand):
             SELECT sd.sensor_id, sdv.value_type, AVG(CAST(sdv."value" AS FLOAT)) as "value", COUNT("value"), sd.location_id
                 FROM sensors_sensordata sd
                     INNER JOIN sensors_sensordatavalue sdv
-                        ON  sd.id = sdv.sensordata_id WHERE "timestamp" >= (NOW() - interval %s)
+                        ON  sdv.sensordata_id = sd.id
+                            AND sdv.value_type <> 'timestamp'
+                WHERE "timestamp" >= (NOW() - interval %s)
                 GROUP BY sd.sensor_id, sdv.value_type, sd.location_id
         ''', [intervals[options['interval']]])
 

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -140,10 +140,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-# Recheck the filesystem to see if any files have changed before responding. 
+# Recheck the filesystem to see if any files have changed before responding.
 WHITENOISE_AUTOREFRESH = True
-# Find and serve files in their original directories using Django’s “finders” API
-# WHITENOISE_USE_FINDERS = True
 
 # Celery Broker
 CELERY_BROKER_URL = os.environ.get(


### PR DESCRIPTION
## Description

Most of [V2](https://github.com/CodeForAfrica/sensors.AFRICA/wiki/APIs#v2) API endpoints assume data is numeric but some sensors send GPS timestamp as data. This hotfix excludes such data points from averaging calculations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation