### PR TITLE
Remove requirements already specified in feinstaub-api/requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
 django==1.11.21 #LTS
-django-extensions==2.1.4
-django-filter==2.0.0
-djangorestframework==3.9.1
-psycopg2==2.7.6.1
 coreapi==2.3.3
 dj-database-url==0.5.0
 timeago==1.0.10
@@ -11,15 +7,12 @@ flower==0.9.2
 tornado<6
 sentry-sdk==0.7.3
 celery==4.2.1
-gunicorn==19.9.0
 gevent==1.2.2
 greenlet==0.4.12
 whitenoise==4.1.2
 
 eradicate==1.0
-pylama==7.6.6
 pytest==5.2.1
-pytest-django==3.4.5
 
 ckanapi==4.1
 


### PR DESCRIPTION
## Description

Remove requirements already specified in feinstaub-api/requirements.txt
This will avoid dependbot bumping versions and causing issues since we use feinstaub-api as a package.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation