### PR TITLE
Hotfix make the lastactive sensor query faster

### DIFF
--- a/sensorsafrica/management/commands/cache_lastactive_nodes.py
+++ b/sensorsafrica/management/commands/cache_lastactive_nodes.py
@@ -18,12 +18,13 @@ class Command(BaseCommand):
                     FROM
                         sensors_sensordata sd
                         INNER JOIN sensors_sensor s ON s.id = sd.sensor_id
-                            AND s.sensor_type_id IN(1, 9)
                             INNER JOIN sensors_node sn ON sn.id = s.node_id
+                            INNER JOIN sensors_sensordatavalue sv ON sv.sensordata_id = sd.id
+                            AND sv.value_type in ('P1', 'P2')
                         WHERE
                             "timestamp" >= now() - INTERVAL '5 min'
                         GROUP BY
-                            sn.id;
+                            sn.id
                 """)
             latest = cursor.fetchall()
             for data in latest:

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -161,7 +161,7 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(hour="*", minute=0)
     },
     "cache-lastactive-nodes-task": {
-        "task": "sensorsafrica.tasks.cache_lastactive_nodes_data",
+        "task": "sensorsafrica.tasks.cache_lastactive_nodes",
         "schedule": crontab(minute="*/5")
     },
     "cache-static-json-data": {

--- a/sensorsafrica/tasks.py
+++ b/sensorsafrica/tasks.py
@@ -13,8 +13,8 @@ def archive_data():
 
 
 @shared_task
-def cache_lastactive_nodes_data():
-    call_command("cache_lastactive_nodes_data")
+def cache_lastactive_nodes():
+    call_command("cache_lastactive_nodes")
 
 
 @shared_task

--- a/sensorsafrica/tests/test_lastactive.py
+++ b/sensorsafrica/tests/test_lastactive.py
@@ -1,0 +1,26 @@
+import pytest
+import pytz
+
+from rest_framework.test import APIRequestFactory
+from feinstaub.sensors.views import PostSensorDataView
+from sensorsafrica.api.models import LastActiveNodes
+
+
+@pytest.mark.django_db
+class TestLastActiveSensor:
+    def test_lastactive_command(self, sensors, last_active):
+        sensors0_node = LastActiveNodes.objects.filter(
+            node=sensors[0].node_id
+        ).get()
+        sensors3_node = LastActiveNodes.objects.filter(
+            node=sensors[3].node_id
+        ).get()
+        sensors4_node = LastActiveNodes.objects.filter(
+            node=sensors[4].node_id
+        ).get()
+
+        assert sensors0_node.last_data_received_at == last_active[0]
+        assert sensors3_node.last_data_received_at == last_active[1]
+        # Sensor is last active when they send the P1 and P2
+        # Sensor[4] sent a none P1/P2 at timestamp last_active[2]
+        assert sensors4_node.last_data_received_at != last_active[2]


### PR DESCRIPTION
## Description

Make the query for the last active sensor to be faster so that the lastactive sensors show up on the map and in the /v2/nodes query

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation