### PR TITLE
[Feature] Public / Private Data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-django==1.11.27 #LTS
+django==1.11.29 #LTS
 coreapi==2.3.3
 dj-database-url==0.5.0
 timeago==1.0.10
 
-flower==0.9.2
+flower==0.9.5
 tornado<6
-sentry-sdk==0.7.3
+sentry-sdk==0.19.5
 celery==4.2.1
 gevent==1.2.2
 greenlet==0.4.12

--- a/sensorsafrica/api/v2/router.py
+++ b/sensorsafrica/api/v2/router.py
@@ -1,18 +1,26 @@
 from rest_framework import routers
 from django.conf.urls import url, include
 
-from .views import CitiesView, NodesView, SensorDataStatsView, SensorLocationsView, SensorTypesView, SensorsView
+from .views import (
+    CitiesView,
+    NodesView,
+    SensorDataStatsView,
+    SensorDataView,
+    SensorLocationsView,
+    SensorTypesView,
+    SensorsView,
+)
+
+stat_data_router = routers.DefaultRouter()
+stat_data_router.register(r"", SensorDataStatsView)
 
 data_router = routers.DefaultRouter()
-
-data_router.register(r"", SensorDataStatsView)
+data_router.register(r"", SensorDataView)
 
 cities_router = routers.DefaultRouter()
-
 cities_router.register(r"", CitiesView, basename="cities")
 
 nodes_router = routers.DefaultRouter()
-
 nodes_router.register(r"", NodesView, basename="map")
 
 sensors_router = routers.DefaultRouter()
@@ -25,7 +33,8 @@ sensor_types_router = routers.DefaultRouter()
 sensor_types_router.register(r"", SensorTypesView, basename="sensor_types")
 
 api_urls = [
-    url(r"data/(?P<sensor_type>[air]+)/", include(data_router.urls)),
+    url(r"data/(?P<sensor_type>[air]+)/", include(stat_data_router.urls)),
+    url(r"data/", include(data_router.urls)),
     url(r"cities/", include(cities_router.urls)),
     url(r"nodes/", include(nodes_router.urls)),
     url(r"locations/", include(sensor_locations_router.urls)),


### PR DESCRIPTION
## Description

This PR adds the needed distinction between **private** (visible to only certain orgs) and **public** (basically what's on sensorsAFRICA site right now) data.
 
 - [x] `calculate_data_statistics.py` method is updated to only work with public data: This means we can now merge data from other networks into the main database without worrying them showing up on the site (as long as we set node/sensor data to private when uploading that is).
 - [x] `/v2/data` now returns all sensor data (using [CursorPagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination) which promises efficiency over features)
 
Private data access is as follows: If the requesting user is the _owner_ of sensor data/node, they have access. Otherwise, the requesting user must belong to one of the groups that the sensor data/node owner belongs to. This means:

  1. Each node added will belong to one group; that is the network e.g. `PurpleAir`.
  2. For each user/token that needs access to `PurpleAir`, we'll add `PurpleAir` to one of the groups the user/token belongs to.

After exhaustively testing this PR, we should deploy develop to sensorsAFRICA and start pushing in data from all networks that we have access to.

**OTHERS**:

Basic dependencies are upgraded to the latest security releases

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation