### PR TITLE
[Feature] Make v1/now return public data only

### DIFF
--- a/sensorsafrica/api/v1/router.py
+++ b/sensorsafrica/api/v1/router.py
@@ -2,14 +2,13 @@
 from feinstaub.main.views import UsersView
 from feinstaub.sensors.views import (
     NodeView,
-    NowView,
     PostSensorDataView,
     SensorView,
     StatisticsView,
     SensorDataView,
 )
 
-from .views import SensorDataView as SensorsAfricaSensorDataView, FilterView
+from .views import FilterView, NowView, SensorDataView as SensorsAfricaSensorDataView
 
 from rest_framework import routers
 

--- a/sensorsafrica/api/v1/views.py
+++ b/sensorsafrica/api/v1/views.py
@@ -2,17 +2,52 @@ import datetime
 import pytz
 import json
 
-from rest_framework.exceptions import ValidationError
 
 from django.conf import settings
-from django.utils import timezone
-from dateutil.relativedelta import relativedelta
 from django.db.models import ExpressionWrapper, F, FloatField, Max, Min, Sum, Avg, Q
 from django.db.models.functions import Cast, TruncDate
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 from rest_framework import mixins, pagination, viewsets
+from rest_framework.exceptions import ValidationError
+
+from feinstaub.sensors.models import SensorData
+from feinstaub.sensors.serializers import NowSerializer
 
 from .serializers import SensorDataSerializer
-from feinstaub.sensors.models import SensorData
+
+class FilterView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    serializer_class = SensorDataSerializer
+
+    def get_queryset(self):
+        sensor_type = self.request.GET.get("type", r"\w+")
+        country = self.request.GET.get("country", r"\w+")
+        city = self.request.GET.get("city", r"\w+")
+        return (
+            SensorData.objects.filter(
+                timestamp__gte=timezone.now() - datetime.timedelta(minutes=5),
+                sensor__sensor_type__uid__iregex=sensor_type,
+                location__country__iregex=country,
+                location__city__iregex=city,
+            )
+            .only("sensor", "timestamp")
+            .prefetch_related("sensordatavalues")
+        )
+
+
+class NowView(mixins.ListModelMixin, viewsets.GenericViewSet):
+    """Show all public sensors active in the last 5 minutes with newest value"""
+
+    permission_classes = []
+    serializer_class = NowSerializer
+    queryset = SensorData.objects.none()
+
+    def get_queryset(self):
+        now = timezone.now()
+        startdate = now - datetime.timedelta(minutes=5)
+        return SensorData.objects.filter(
+            sensor__public=True, modified__range=[startdate, now]
+        )
 
 
 class SensorDataView(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -20,31 +55,10 @@ class SensorDataView(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def get_queryset(self):
         return (
-            SensorData.objects
-            .filter(
+            SensorData.objects.filter(
                 timestamp__gte=timezone.now() - datetime.timedelta(minutes=5),
-                sensor=self.kwargs["sensor_id"]
+                sensor=self.kwargs["sensor_id"],
             )
-            .only('sensor', 'timestamp')
-            .prefetch_related('sensordatavalues')
-        )
-
-
-class FilterView(mixins.ListModelMixin, viewsets.GenericViewSet):
-    serializer_class = SensorDataSerializer
-
-    def get_queryset(self):
-        sensor_type = self.request.GET.get('type', r'\w+')
-        country = self.request.GET.get('country', r'\w+')
-        city = self.request.GET.get('city', r'\w+')
-        return (
-            SensorData.objects
-            .filter(
-                timestamp__gte=timezone.now() - datetime.timedelta(minutes=5),
-                sensor__sensor_type__uid__iregex=sensor_type,
-                location__country__iregex=country,
-                location__city__iregex=city
-            )
-            .only('sensor', 'timestamp')
-            .prefetch_related('sensordatavalues')
+            .only("sensor", "timestamp")
+            .prefetch_related("sensordatavalues")
         )


### PR DESCRIPTION
## Description

Currently, `v1/now` returns data from all sensors, public and private. This PR makes `v1/now` return data from public sensors only by default.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation