### PR TITLE
[Fix] v1/node should check groups

### DIFF
--- a/sensorsafrica/api/v1/router.py
+++ b/sensorsafrica/api/v1/router.py
@@ -1,14 +1,18 @@
 # The base version is entirely based on feinstaub
 from feinstaub.main.views import UsersView
 from feinstaub.sensors.views import (
-    NodeView,
     PostSensorDataView,
     SensorView,
     StatisticsView,
     SensorDataView,
 )
 
-from .views import FilterView, NowView, SensorDataView as SensorsAfricaSensorDataView
+from .views import (
+    FilterView,
+    NodeView,
+    NowView,
+    SensorDataView as SensorsAfricaSensorDataView,
+)
 
 from rest_framework import routers
 
@@ -20,8 +24,9 @@ router.register(r"data", SensorDataView)
 router.register(r"statistics", StatisticsView, basename="statistics")
 router.register(r"now", NowView)
 router.register(r"user", UsersView)
-router.register(r"sensors/(?P<sensor_id>\d+)",
-                SensorsAfricaSensorDataView, basename="sensors")
+router.register(
+    r"sensors/(?P<sensor_id>\d+)", SensorsAfricaSensorDataView, basename="sensors"
+)
 router.register(r"filter", FilterView, basename="filter")
 
 api_urls = router.urls


### PR DESCRIPTION
## Description

In order to have groups share nodes, we need to update `/v1/node` to also check if nodes belong to common group.

To improve performance this PR also adds standard pagination to `/v1/node` to help browse those networks/groups with a lot of nodes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation