### PR TITLE
[Feature] /v2/nodes should include node owner

### DIFF
--- a/sensorsafrica/api/v2/views.py
+++ b/sensorsafrica/api/v2/views.py
@@ -193,7 +193,7 @@ class NodesView(viewsets.ViewSet):
                 {
                     "node_moved": moved_to is not None,
                     "moved_to": moved_to,
-                    "node": {"uid": last_active.node.uid, "id": last_active.node.id},
+                    "node": {"uid": last_active.node.uid, "id": last_active.node.id, "owner": last_active.node.owner},
                     "location": {
                         "name": last_active.location.location,
                         "longitude": last_active.location.longitude,


### PR DESCRIPTION
## Description

Node's owner id should be returned as part of /v2/nodes. This id can be used to identify the network a given node belongs to.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation