### PR TITLE
[HotFix] NodeView default queryset

### DIFF
--- a/sensorsafrica/api/v1/views.py
+++ b/sensorsafrica/api/v1/views.py
@@ -49,7 +49,7 @@ class NodeView(
     authentication_classes = [SessionAuthentication, TokenAuthentication]
     pagination_class = StandardResultsSetPagination
     permission_classes = [IsAuthenticatedOrReadOnly]
-    queryset = SensorData.objects.none()
+    queryset = Node.objects.none()
     serializer_class = NodeSerializer
     filter_class = NodeFilter
 


### PR DESCRIPTION
## Description

NodeView default queryset was set to SensorData instead of Node.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code