### PR TITLE
Ensure data is return from public sensors only

### DIFF
--- a/sensorsafrica/api/v2/views.py
+++ b/sensorsafrica/api/v2/views.py
@@ -160,6 +160,9 @@ class NodesView(viewsets.ViewSet):
                 stats = (
                     SensorDataValue.objects.filter(
                         Q(sensordata__sensor__node=last_active.node.id),
+                        # Open endpoints should return data from public sensors
+                        # only.
+                        Q(sensordata__sensor__public=True),
                         Q(sensordata__location=last_active.location.id),
                         Q(sensordata__timestamp__gte=last_5_mins),
                         Q(sensordata__timestamp__lte=last_data_received_at),


### PR DESCRIPTION
## Description

`/v2/nodes` seem to return data from both private and public sensors. This PR restricts the endpoint to returning public data only. Private data can still be return via `/v1/node` when authentication is provided.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
