### PR TITLE
/v2/nodes shouldn't nodes with at least one public sensor

### DIFF
--- a/sensorsafrica/api/v2/views.py
+++ b/sensorsafrica/api/v2/views.py
@@ -143,10 +143,12 @@ class NodesView(viewsets.ViewSet):
         nodes = []
         # Loop through the last active nodes
         for last_active in LastActiveNodes.objects.iterator():
-            # Get the current node
+            # Get the current node only if it has public sensors
             node = Node.objects.filter(
-                Q(id=last_active.node.id), ~Q(sensors=None)
-            ).get()
+                Q(id=last_active.node.id), Q(sensors__public=True)
+            ).first()
+            if node is None:
+                continue
 
             # The last acive date
             last_data_received_at = last_active.last_data_received_at
@@ -161,7 +163,7 @@ class NodesView(viewsets.ViewSet):
                     SensorDataValue.objects.filter(
                         Q(sensordata__sensor__node=last_active.node.id),
                         # Open endpoints should return data from public sensors
-                        # only.
+                        # only in case a node has both public & private sensors
                         Q(sensordata__sensor__public=True),
                         Q(sensordata__location=last_active.location.id),
                         Q(sensordata__timestamp__gte=last_5_mins),
@@ -214,6 +216,7 @@ class NodesView(viewsets.ViewSet):
                     "stats": stats,
                 }
             )
+
         return Response(nodes)
 
     def create(self, request):


### PR DESCRIPTION
## Description

While https://github.com/CodeForAfrica/sensors.AFRICA-api/pull/120 ensured only public data is returned, this PR ensures only nodes with public sensors are returned in /v2/nodes since this endpoint is used to display nodes on a publicly visible map.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
