### PR TITLE
Fix/node list access

### DIFF
--- a/sensorsafrica/api/v2/views.py
+++ b/sensorsafrica/api/v2/views.py
@@ -139,10 +139,10 @@ class NodesView(viewsets.ViewSet):
     def list_nodes(self, request):
         """List all public nodes with active sensors."""
         now = datetime.datetime.now()
-        one_hour_ago = now - datetime.timedelta(hours=1)
+        one_year_ago = now - datetime.timedelta(days=365)
 
         last_active_nodes = (
-            LastActiveNodes.objects.filter(last_data_received_at__gte=one_hour_ago)
+            LastActiveNodes.objects.filter(last_data_received_at__gte=one_year_ago)
             .select_related("node", "location")
             .prefetch_related(
                 Prefetch(


### PR DESCRIPTION
## Description

This PR introduces the following changes to the `list_nodes` action on the NodesView
1. Allow non-authenticated access to fetch nodes, e.g `v2.map.aq.sensors`
2. Optimize to fetch only LastActiveNodes within the last 1 hour and make joins to fetch `nodes` and `locations`. We need to only display statistics within the last 5 min range, and we post new data every 3-5 mins

PS: As per @gideonmaina the ideal time frame to tell an active node is that which has transmitted data within last 1 year (Old sensors, last updated in 2017,2018 still appear in DB & yet to be decommissioned) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation