### PR TITLE
Optimize cron job schedules and enhance data caching

### DIFF
--- a/sensorsafrica/management/commands/cache_static_json_data.py
+++ b/sensorsafrica/management/commands/cache_static_json_data.py
@@ -44,9 +44,14 @@ class Command(BaseCommand):
         parser.add_argument('--interval', type=str)
 
     def handle(self, *args, **options):
-        intervals = {'5m': '5 minutes', '1h': '1 hour', '24h': '24 hours'}
+        intervals = {'5m': '5 minutes', '30m': '30 minutes', '1h': '1 hour', '24h': '24 hours'}
         paths = {
             '5m': [
+                '../../../static/v2/data.json',
+                '../../../static/v2/data.dust.min.json',
+                '../../../static/v2/data.temp.min.json'
+            ],
+            '30m': [
                 '../../../static/v2/data.json',
                 '../../../static/v2/data.dust.min.json',
                 '../../../static/v2/data.temp.min.json'
@@ -66,28 +71,44 @@ class Command(BaseCommand):
                 GROUP BY sd.sensor_id, sdv.value_type, sd.location_id
         ''', [intervals[options['interval']]])
 
-        data = {}
-        while True:
-            row = cursor.fetchone()
-            if row is None:
-                break
+        # Fetch all rows once and build maps to avoid N+1 ORM queries
+        rows = cursor.fetchall()
+        if not rows:
+            return
 
-            if row[0] in data:
-                data[row[0]]['sensordatavalues'].append(dict({
-                    'samples': row[3],
-                    'value': row[2],
-                    'value_type': row[1]
-                }))
-            else:
-                data[row[0]] = dict({
-                    'location': SensorLocationSerializer(SensorLocation.objects.get(pk=row[4])).data,
-                    'sensor': SensorSerializer(Sensor.objects.get(pk=row[0])).data,
-                    'sensordatavalues': [{
-                        'samples': row[3],
-                        'value': row[2],
-                        'value_type': row[1]
-                    }]
+        sensor_ids = set([r[0] for r in rows])
+        location_ids = set([r[4] for r in rows if r[4] is not None])
+
+        sensors_qs = Sensor.objects.filter(pk__in=sensor_ids).select_related('sensor_type')
+        sensor_map = {s.pk: SensorSerializer(s).data for s in sensors_qs}
+
+        locations_qs = SensorLocation.objects.filter(pk__in=location_ids)
+        location_map = {l.pk: SensorLocationSerializer(l).data for l in locations_qs}
+
+        data = {}
+        for row in rows:
+            sid = row[0]
+            val_type = row[1]
+            avg_value = row[2]
+            sample_count = row[3]
+            loc_id = row[4]
+
+            if sid in data:
+                data[sid]['sensordatavalues'].append({
+                    'samples': sample_count,
+                    'value': avg_value,
+                    'value_type': val_type,
                 })
+            else:
+                data[sid] = {
+                    'location': location_map.get(loc_id) if loc_id in location_map else None,
+                    'sensor': sensor_map.get(sid),
+                    'sensordatavalues': [{
+                        'samples': sample_count,
+                        'value': avg_value,
+                        'value_type': val_type,
+                    }],
+                }
 
         for path in paths[options['interval']]:
             with open(

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -161,28 +161,28 @@ CELERY_BROKER_URL = os.environ.get(
 )
 CELERY_IGNORE_RESULT = True
 
-CELERY_BEAT_SCHEDULE = {
-    "statistics-task": {
-        "task": "sensorsafrica.tasks.calculate_data_statistics",
-        "schedule": crontab(hour="*", minute=0),
-    },
-    "archive-task": {
-        "task": "sensorsafrica.tasks.archive_data",
-        "schedule": crontab(hour="*", minute=0),
-    },
-    "cache-lastactive-nodes-task": {
-        "task": "sensorsafrica.tasks.cache_lastactive_nodes",
-        "schedule": crontab(minute="*/5"),
-    },
-    "cache-static-json-data": {
-        "task": "sensorsafrica.tasks.cache_static_json_data",
-        "schedule": crontab(minute="*/5"),
-    },
-    "cache-static-json-data-1h-24h": {
-        "task": "sensorsafrica.tasks.cache_static_json_data_1h_24h",
-        "schedule": crontab(hour="*", minute=0),
-    },
-}
+# CELERY_BEAT_SCHEDULE = {
+#     "statistics-task": {
+#         "task": "sensorsafrica.tasks.calculate_data_statistics",
+#         "schedule": crontab(hour="*", minute=0),
+#     },
+#     "archive-task": {
+#         "task": "sensorsafrica.tasks.archive_data",
+#         "schedule": crontab(hour="*", minute=0),
+#     },
+#     "cache-lastactive-nodes-task": {
+#         "task": "sensorsafrica.tasks.cache_lastactive_nodes",
+#         "schedule": crontab(minute="*/5"),
+#     },
+#     "cache-static-json-data": {
+#         "task": "sensorsafrica.tasks.cache_static_json_data",
+#         "schedule": crontab(minute="*/5"),
+#     },
+#     "cache-static-json-data-1h-24h": {
+#         "task": "sensorsafrica.tasks.cache_static_json_data_1h_24h",
+#         "schedule": crontab(hour="*", minute=0),
+#     },
+# }
 
 
 # Sentry

--- a/sensorsafrica/settings.py
+++ b/sensorsafrica/settings.py
@@ -161,28 +161,28 @@ CELERY_BROKER_URL = os.environ.get(
 )
 CELERY_IGNORE_RESULT = True
 
-# CELERY_BEAT_SCHEDULE = {
-#     "statistics-task": {
-#         "task": "sensorsafrica.tasks.calculate_data_statistics",
-#         "schedule": crontab(hour="*", minute=0),
-#     },
-#     "archive-task": {
-#         "task": "sensorsafrica.tasks.archive_data",
-#         "schedule": crontab(hour="*", minute=0),
-#     },
-#     "cache-lastactive-nodes-task": {
-#         "task": "sensorsafrica.tasks.cache_lastactive_nodes",
-#         "schedule": crontab(minute="*/5"),
-#     },
-#     "cache-static-json-data": {
-#         "task": "sensorsafrica.tasks.cache_static_json_data",
-#         "schedule": crontab(minute="*/5"),
-#     },
-#     "cache-static-json-data-1h-24h": {
-#         "task": "sensorsafrica.tasks.cache_static_json_data_1h_24h",
-#         "schedule": crontab(hour="*", minute=0),
-#     },
-# }
+CELERY_BEAT_SCHEDULE = {
+    "cache_lastactive_nodes": {
+        "task": "sensorsafrica.tasks.cache_lastactive_nodes",
+        "schedule": crontab(minute=2, hour="*/4"),
+    },
+    "cache_static_json_data": {
+        "task": "sensorsafrica.tasks.cache_static_json_data",
+        "schedule": crontab(minute="0,30"),
+    },
+    "cache_static_json_data_1h_24h": {
+        "task": "sensorsafrica.tasks.cache_static_json_data_1h_24h",
+        "schedule": crontab(minute=10),
+    },
+    "calculate_data_statistics": {
+        "task": "sensorsafrica.tasks.calculate_data_statistics",
+        "schedule": crontab(hour="6,18", minute=0),
+    },
+    "archive_data": {
+        "task": "sensorsafrica.tasks.archive_data",
+        "schedule": crontab(hour=0, minute=0),
+    },
+}
 
 
 # Sentry

--- a/sensorsafrica/tasks.py
+++ b/sensorsafrica/tasks.py
@@ -2,27 +2,27 @@ from celery import shared_task
 from django.core.management import call_command
 
 
-@shared_task
-def calculate_data_statistics():
-    call_command("calculate_data_statistics")
+# @shared_task
+# def calculate_data_statistics():
+#     call_command("calculate_data_statistics")
 
 
-@shared_task
-def archive_data():
-    call_command("upload_to_ckan")
+# @shared_task
+# def archive_data():
+#     call_command("upload_to_ckan")
 
 
-@shared_task
-def cache_lastactive_nodes():
-    call_command("cache_lastactive_nodes")
+# @shared_task
+# def cache_lastactive_nodes():
+#     call_command("cache_lastactive_nodes")
 
 
-@shared_task
-def cache_static_json_data():
-    call_command("cache_static_json_data", interval='5m')
+# @shared_task
+# def cache_static_json_data():
+#     call_command("cache_static_json_data", interval='5m')
 
 
-@shared_task
-def cache_static_json_data_1h_24h():
-    call_command("cache_static_json_data", interval='1h')
-    call_command("cache_static_json_data", interval='24h')
+# @shared_task
+# def cache_static_json_data_1h_24h():
+#     call_command("cache_static_json_data", interval='1h')
+#     call_command("cache_static_json_data", interval='24h')

--- a/sensorsafrica/tasks.py
+++ b/sensorsafrica/tasks.py
@@ -2,27 +2,28 @@ from celery import shared_task
 from django.core.management import call_command
 
 
-# @shared_task
-# def calculate_data_statistics():
-#     call_command("calculate_data_statistics")
+@shared_task
+def calculate_data_statistics():
+    call_command("calculate_data_statistics")
 
 
-# @shared_task
-# def archive_data():
-#     call_command("upload_to_ckan")
+@shared_task
+def archive_data():
+    call_command("upload_to_ckan")
 
 
-# @shared_task
-# def cache_lastactive_nodes():
-#     call_command("cache_lastactive_nodes")
+@shared_task
+def cache_lastactive_nodes():
+    call_command("cache_lastactive_nodes")
 
 
-# @shared_task
-# def cache_static_json_data():
-#     call_command("cache_static_json_data", interval='5m')
+@shared_task
+def cache_static_json_data():
+    # Run the 30-minute aggregation
+    call_command("cache_static_json_data", interval='30m')
 
 
-# @shared_task
-# def cache_static_json_data_1h_24h():
-#     call_command("cache_static_json_data", interval='1h')
-#     call_command("cache_static_json_data", interval='24h')
+@shared_task
+def cache_static_json_data_1h_24h():
+    call_command("cache_static_json_data", interval='1h')
+    call_command("cache_static_json_data", interval='24h')


### PR DESCRIPTION
# Summary
Optimize Celery scheduled jobs to reduce database load and enable safer periodic execution.

# What changed
- Enabled and updated Celery beat schedule in `settings.py`
- Enabled task wrappers in `tasks.py`.
- Refactored `cache_static_json_data.py` to remove N+1 ORM lookups

# Key improvements
- **cache_lastactive_nodes**
  - Runs every 4 hours instead of every 5 minutes
  - Reduces frequent DB hits for node activity aggregation
  
- **cache_static_json_data**
  - Runs every 30 minutes
  - Bulk-loads related sensor and location data
  - Eliminates repeated `SensorLocation.objects.get(...)` and `Sensor.objects.get(...)` calls

- **calculate_data_statistics**
  - Scheduled at `06:00` and `18:00`
  - Splits processing into two 12-hour windows to lower load

- **archive_data**
  - Moved to midnight (`00:00`)
  - Ensures heavy archive work runs at off-peak hours

## Why this helps
1. Spreads expensive jobs apart to prevent concurrent load spikes
2. Reduces DB pressure by lowering frequency of frequent tasks
3. Improves `cache_static_json_data` performance by avoiding N+1 query patterns

# Files updated
1. settings.py
2. tasks.py
3. cache_static_json_data.py

# Testing
- [x] Verify Celery beat schedule loads correctly
- [x] Confirm the refactored `cache_static_json_data` command still writes expected JSON outputs
- [x] Run scheduled task workflows in a development environment and monitor DB query volume